### PR TITLE
LI-7 | Separate top and bottom bars from screens content

### DIFF
--- a/app/src/main/java/com/app/limboapp/screens/ChaptersScreen.kt
+++ b/app/src/main/java/com/app/limboapp/screens/ChaptersScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -26,26 +25,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.app.limboapp.common.LimboTopBar
 import com.app.limboapp.model.ChapterData
-import com.app.limboapp.model.TopBarMode
-import com.app.limboapp.nav.LimboBottomNavigation
 import com.app.limboapp.ui.theme.*
 
 @Preview
 @Composable
 fun ChaptersScreen() {
-    Scaffold(
-        backgroundColor = BlackBackground,
-        topBar = {
-            LimboTopBar(mode = TopBarMode.PROFILE)
-        },
-        bottomBar = {
-            LimboBottomNavigation()
-        }
-    ) { paddingValues ->
-        ChaptersSection(Modifier.padding(paddingValues))
-    }
+    ChaptersSection(modifier = Modifier.background(BlackBackground))
 }
 
 @Composable

--- a/app/src/main/java/com/app/limboapp/screens/HomeScreen.kt
+++ b/app/src/main/java/com/app/limboapp/screens/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,11 +37,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.limboapp.R
-import com.app.limboapp.common.LimboTopBar
 import com.app.limboapp.model.ChapterData
 import com.app.limboapp.model.Person
-import com.app.limboapp.model.TopBarMode
-import com.app.limboapp.nav.LimboBottomNavigation
 import com.app.limboapp.ui.theme.BlackBackground
 import com.app.limboapp.ui.theme.MiniFlickersBackground
 import com.app.limboapp.ui.theme.Montserrat
@@ -56,24 +52,7 @@ import com.app.limboapp.ui.theme.redGradient
 
 @Composable
 fun HomeScreen() {
-    Scaffold(
-        backgroundColor = BlackBackground,
-        topBar = {
-            LimboTopBar(mode = TopBarMode.PROFILE)
-        },
-        bottomBar = {
-            LimboBottomNavigation()
-        }
-    ) {
-        Column(
-            modifier = Modifier
-                .padding(paddingValues = it)
-        ) {
-            BestInGroupSection()
-            Spacer(modifier = Modifier.height(20.dp))
-            MiniChapterSection()
-        }
-    }
+    HomeSection(modifier = Modifier.background(BlackBackground))
 }
 
 @Composable
@@ -276,6 +255,15 @@ fun MiniChapterSection(modifier: Modifier = Modifier) {
     }
 }
 
+@Composable
+fun HomeSection(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        BestInGroupSection()
+        Spacer(modifier = Modifier.height(20.dp))
+        MiniChapterSection()
+    }
+}
+
 // ------------------
 
 @Preview
@@ -318,6 +306,12 @@ fun MiniChapterSectionPreview() {
 @Composable
 fun HomeScreenPreview() {
     HomeScreen()
+}
+
+@Preview
+@Composable
+fun HomeSectionPreview() {
+    HomeSection()
 }
 
 // ------------------

--- a/app/src/main/java/com/app/limboapp/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/app/limboapp/screens/ProfileScreen.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -22,34 +21,25 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.limboapp.R
 import com.app.limboapp.common.CircleImage
-import com.app.limboapp.common.LimboTopBar
-import com.app.limboapp.model.TopBarMode
-import com.app.limboapp.nav.LimboBottomNavigation
 import com.app.limboapp.ui.theme.*
 
 @Preview
 @Composable
 fun ProfileScreen() {
-    Scaffold(
-        backgroundColor = BlackBackground,
-        topBar = {
-            LimboTopBar(mode = TopBarMode.LOGOUT)
-        },
-        bottomBar = {
-            LimboBottomNavigation()
-        }
-    ) { paddingValues ->
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(paddingValues)
-        ) {
-            Spacer(modifier = Modifier.height(8.dp))
-            ProfileInfo()
-            ChangePassword(Modifier.padding(top = 16.dp))
-            RedeemFlickersSection(Modifier.padding(top = 30.dp, bottom = 16.dp))
-        }
+    ProfileSection(modifier = Modifier.background(BlackBackground))
+}
+
+@Composable
+fun ProfileSection(modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = Modifier.height(8.dp))
+        ProfileInfo()
+        ChangePassword(Modifier.padding(top = 16.dp))
+        RedeemFlickersSection(Modifier.padding(top = 30.dp, bottom = 16.dp))
     }
 }
 
@@ -234,4 +224,10 @@ fun RedeemFlickersSectionPreview() {
 @Composable
 fun ProfileInfoPreview() {
     ProfileInfo()
+}
+
+@Preview
+@Composable
+fun ProfileSectionPreview() {
+    ProfileSection()
 }

--- a/app/src/main/java/com/app/limboapp/screens/ReedemPointsScreen.kt
+++ b/app/src/main/java/com/app/limboapp/screens/ReedemPointsScreen.kt
@@ -1,6 +1,7 @@
 package com.app.limboapp.screens
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,30 +24,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.app.limboapp.R
-import com.app.limboapp.common.LimboTopBar
-import com.app.limboapp.model.TopBarMode
-import com.app.limboapp.nav.LimboBottomNavigation
 import com.app.limboapp.ui.theme.BlackBackground
 import com.app.limboapp.ui.theme.Montserrat
 import com.app.limboapp.ui.theme.TextWhite
 
 @Composable
 fun RedeemPointsScreen() {
-    Scaffold(
-        backgroundColor = BlackBackground,
-        topBar = {
-            LimboTopBar(mode = TopBarMode.PROFILE)
-        },
-        bottomBar = {
-            LimboBottomNavigation()
-        }
-    ) { paddingValues ->
-        RedeemPointsContent(
-            modifier = Modifier
-                .padding(horizontal = 20.dp)
-                .padding(paddingValues)
-        )
-    }
+    RedeemPointsContent(
+        modifier = Modifier
+            .background(BlackBackground)
+            .padding(horizontal = 20.dp)
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/app/limboapp/screens/StatsScreen.kt
+++ b/app/src/main/java/com/app/limboapp/screens/StatsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,9 +27,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.app.limboapp.common.LimboTopBar
-import com.app.limboapp.model.TopBarMode
-import com.app.limboapp.nav.LimboBottomNavigation
 import com.app.limboapp.ui.theme.BlackBackground
 import com.app.limboapp.ui.theme.Montserrat
 import com.app.limboapp.ui.theme.TextWhite
@@ -39,17 +35,7 @@ import com.app.limboapp.ui.theme.orangeGradient
 
 @Composable
 fun StatsScreen() {
-    Scaffold(
-        backgroundColor = BlackBackground,
-        topBar = {
-            LimboTopBar(mode = TopBarMode.PROFILE)
-        },
-        bottomBar = {
-            LimboBottomNavigation()
-        }
-    ) { paddingValues ->
-        StatsScreenContent(modifier = Modifier.padding(paddingValues))
-    }
+    StatsScreenContent(modifier = Modifier.background(BlackBackground))
 }
 
 @Composable


### PR DESCRIPTION
Screens can be now implemented in scaffold, where it's content is separated from top and bottom bars. Also refactored some code.